### PR TITLE
Add Teams model

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class TeamsController < ApplicationController
+  def index
+    render json: Team.all.pluck(:coverage).flatten
+  end
+end

--- a/app/javascript/packs/home/app.jsx
+++ b/app/javascript/packs/home/app.jsx
@@ -93,6 +93,13 @@ const LOCATION = {
 
 function App() {
   const [location, setLocation] = React.useState(null);
+  const [chapters, setChapters] = React.useState([]);
+
+  React.useEffect(() => {
+    window.fetch("/teams").then((response) => response.json()).then((json) => {
+      setChapters(json);
+    });
+  }, []);
 
   return (
     <React.Fragment>
@@ -100,7 +107,7 @@ function App() {
       <Map
         mapboxToken={MAPBOX_TOKEN}
         location={location || LOCATION}
-        chapters={CHAPTERS}
+        chapters={chapters}
         className="freeforestmap"
         setLocation={setLocation}
       />

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,0 +1,3 @@
+class Team < ActiveRecord::Base
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,6 @@
 
 Rails.application.routes.draw do
   get '/', to: 'home#index'
+
+  resources :teams, only: [:index]
 end

--- a/db/migrate/20200405211516_add_teams.rb
+++ b/db/migrate/20200405211516_add_teams.rb
@@ -1,0 +1,8 @@
+class AddTeams < ActiveRecord::Migration[6.0]
+  def change
+    create_table :teams do |t|
+      t.string :name
+      t.json :coverage
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,23 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_04_05_215003) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "teams", force: :cascade do |t|
+    t.string "name"
+    t.json "coverage"
+  end
+
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,27 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+#
+Team.create(
+  name: "(CA) Marin County, CA",
+  coverage: [
+    {"type":"Feature","id":"6041","properties":{"type": "Chapter", "name": "CA - Marin County", "learnMoreLink": "https://www.freeforestschool.org/free-forest-school-marin-county-california", "fbLink": "https://www.facebook.com/groups/FreeForestSchoolMarinCountyCA"}, "geometry":{"type":"Polygon","coordinates":[[[-122.844393,38.27639],[-122.488392,38.112082],[-122.504823,37.821804],[-123.014178,38.002543],[-123.003224,38.298298],[-122.844393,38.27639]]]} }
+  ]
+)
+
+Team.create(
+  name: "(CA) SF East Bay, CA",
+  coverage: [
+    {"type":"Feature","id":"6001","properties":{"type": "Chapter", "name": "CA - SF East Bay", "learnMoreLink": "https://www.freeforestschool.org/free-forest-school-sf-east-bay-california", "fbLink": "https://www.facebook.com/groups/FreeForestSchoolSFEastBayCA" },"geometry":{"type":"Polygon","coordinates":[[[-122.269314,37.903958],[-121.557312,37.821804],[-121.469681,37.482234],[-121.475158,37.482234],[-121.853067,37.482234],[-122.083098,37.476757],[-122.11596,37.504141],[-122.31313,37.898481],[-122.269314,37.903958]]]}},
+    {"type":"Feature","id":"6013","properties":{"type": "Chapter", "name": "CA - SF East Bay", "learnMoreLink": "https://www.freeforestschool.org/free-forest-school-sf-east-bay-california", "fbLink": "https://www.facebook.com/groups/FreeForestSchoolSFEastBayCA" },"geometry":{"type":"Polygon","coordinates":[[[-121.628512,38.101128],[-121.57922,38.095651],[-121.557312,37.821804],[-122.269314,37.903958],[-122.31313,37.898481],[-122.269314,38.062789],[-121.864021,38.068266],[-121.628512,38.101128]]]}}
+  ]
+)
+
+Team.create(
+  name: "(CA) San Francisco Peninsula / South Bay, CA",
+  coverage: [
+    {"type":"Feature","id":"6075","properties":{"type": "Chapter", "name": "CA - San Francisco Peninsula / South Bay", "learnMoreLink": "https://www.freeforestschool.org/free-forest-school-san-francisco-south-bay-california", "fbLink": "https://www.facebook.com/groups/FreeForestSchoolSanFranSouthBayCA"},"geometry":{"type":"Polygon","coordinates":[[[-122.428146,37.706788],[-122.504823,37.706788],[-122.389807,37.706788],[-122.428146,37.706788]]]}},
+    {"type":"Feature","id":"6081","properties":{"type": "Chapter", "name": "CA - San Francisco Peninsula / South Bay", "learnMoreLink": "https://www.freeforestschool.org/free-forest-school-san-francisco-south-bay-california", "fbLink": "https://www.facebook.com/groups/FreeForestSchoolSanFranSouthBayCA"},"geometry":{"type":"Polygon","coordinates":[[[-122.428146,37.706788],[-122.389807,37.706788],[-122.11596,37.504141],[-122.083098,37.476757],[-122.154299,37.285064],[-122.291222,37.109802],[-122.504823,37.706788],[-122.428146,37.706788]]]}},
+    {"type":"Feature","id":"6085","properties":{"type": "Chapter", "name": "CA - San Francisco Peninsula / South Bay", "learnMoreLink": "https://www.freeforestschool.org/free-forest-school-san-francisco-south-bay-california", "fbLink": "https://www.facebook.com/groups/FreeForestSchoolSanFranSouthBayCA"},"geometry":{"type":"Polygon","coordinates":[[[-121.853067,37.482234],[-121.475158,37.482234],[-121.228696,37.137186],[-121.217742,36.961924],[-121.447773,36.989309],[-121.57922,36.901678],[-122.154299,37.285064],[-122.083098,37.476757],[-121.853067,37.482234]]]}},
+  ]
+)


### PR DESCRIPTION
### Description

- Team is the term used by Crew2030 for what Free Forest School calls
Chapters. We're using it here because we're still unclear how much data
will live inside this application, but want to keep it as close to
Crew2030's data model.
- coverage is a JSON field representing the boundary the chapter covers
- seeding with data for the SF Bay Area for now
- add API to return data for all chapters for now. Eventually this API will take a lat/long position and only return data nearby that position